### PR TITLE
add some unrelaeted ddl execution, to avoid merge in schema diff queue

### DIFF
--- a/ddl.go
+++ b/ddl.go
@@ -24,6 +24,7 @@ type ddlRandom func(*[]ColumnType, *sql.DB, *Log, *sync.WaitGroup, *sync.WaitGro
 func CreateIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDLWg, readyCommitWg *sync.WaitGroup) {
 	readyDMLWg.Done()
 	threadName := "create-index"
+	var unrelatedTblName string
 	util.AssertNil(log.NewThread(threadName))
 	readyDDLWg.Wait()
 	for i := 0; i < ddlCnt; i++ {
@@ -37,6 +38,10 @@ func CreateIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyD
 			indexMutex.Lock()
 			indexSet[index] = struct{}{}
 			indexMutex.Unlock()
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
+			}
 		}
 	}
 
@@ -46,6 +51,7 @@ func CreateIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyD
 func DropIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDLWg, readyCommitWg *sync.WaitGroup) {
 	readyDMLWg.Done()
 	threadName := "drop-index"
+	var unrelatedTblName string
 	util.AssertNil(log.NewThread(threadName))
 	readyDDLWg.Wait()
 	for i := 0; i < ddlCnt/2; i++ {
@@ -56,6 +62,10 @@ func DropIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDL
 			fmt.Println(err)
 		} else {
 			log.Done(threadName, logIndex, nil)
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
+			}
 		}
 	}
 	readyCommitWg.Done()
@@ -69,6 +79,7 @@ type IndexStmt struct {
 
 func CreateUniqueIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDLWg, readyCommitWg *sync.WaitGroup) {
 	threadName := "create-unique-index"
+	var unrelatedTblName string
 	util.AssertNil(log.NewThread(threadName))
 	stmts := make([]IndexStmt, ddlCnt)
 	for i := 0; i < ddlCnt; i++ {
@@ -93,6 +104,10 @@ func CreateUniqueIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, 
 			uniqueIndexMutex.Lock()
 			uniqueIndexSet[indexStmt.index] = struct{}{}
 			uniqueIndexMutex.Unlock()
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
+			}
 		}
 	}
 	readyCommitWg.Done()
@@ -101,6 +116,7 @@ func CreateUniqueIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, 
 func DropUniqueIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDLWg, readyCommitWg *sync.WaitGroup) {
 	readyDMLWg.Done()
 	threadName := "drop-unique-index"
+	var unrelatedTblName string
 	util.AssertNil(log.NewThread(threadName))
 	readyDDLWg.Wait()
 	for i := 0; i < ddlCnt/2; i++ {
@@ -114,6 +130,10 @@ func DropUniqueIndex(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, re
 			uniqueIndex := uniqueSets.GetIndex(index)
 			if uniqueIndex != nil {
 				uniqueIndex.unique.dropped = true
+			}
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
 			}
 		}
 	}
@@ -229,7 +249,9 @@ func AddColumn(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDL
 	threadName := "add-column"
 	util.AssertNil(log.NewThread(threadName))
 	readyDDLWg.Wait()
-	for i := 0; i < ddlCnt; i++ {
+	var unrelatedTblName string
+	ddlNum := ddlCnt + util.RdRange(1, 10)
+	for i := 0; i < ddlNum; i++ {
 		rndType := kv.RdType()
 		addColumn := NewColumnType(i, fmt.Sprintf("new_col_%d", i), rndType, rndType.Size(), util.RdBool())
 		stmt := fmt.Sprintf("ALTER TABLE %s ADD COLUMN %s", tableName, addColumn.ToColStr())
@@ -239,6 +261,10 @@ func AddColumn(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDDL
 			fmt.Println(err)
 		} else {
 			log.Done(threadName, logIndex, nil)
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
+			}
 		}
 	}
 	readyCommitWg.Done()
@@ -251,6 +277,7 @@ func DropColumn(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDD
 	readyDDLWg.Wait()
 	colNum := len(*columns)
 	leftIndex := 1
+	var unrelatedTblName string
 	if colCnt/2 > leftIndex {
 		leftIndex = colCnt / 2
 	}
@@ -263,7 +290,48 @@ func DropColumn(columns *[]ColumnType, db *sql.DB, log *Log, readyDMLWg, readyDD
 			fmt.Println(err)
 		} else {
 			log.Done(threadName, logIndex, nil)
+			doErr := DoSomeUnrelatedDDLs(db, &unrelatedTblName)
+			if doErr != nil {
+				fmt.Println(fmt.Sprintf("unrelated ddl failed err=%v", doErr))
+			}
 		}
 	}
 	readyCommitWg.Done()
+}
+
+func DoSomeUnrelatedDDLs(db *sql.DB, tableName *string) error {
+	if len(*tableName) > 0 {
+		err := DoUnrelatedDropTableDDL(db, *tableName)
+		if err != nil {
+			return err
+		}
+		*tableName = ""
+	} else {
+		err, name := DoUnrelatedCreateTableDDL(db)
+		if err != nil {
+			return err
+		}
+		*tableName = name
+	}
+	return nil
+}
+
+func DoUnrelatedCreateTableDDL(db *sql.DB) (error, string) {
+	columns, primary := RdColumnsAndPk(5)
+	tableName := fmt.Sprintf("t_%d", time.Now().UnixNano())
+	createStmt := GenCreateTableStmt(columns, primary, tableName)
+	if _, err := db.Exec(createStmt); err != nil {
+		fmt.Println(err)
+		return err, ""
+	}
+	return nil, tableName
+}
+
+func DoUnrelatedDropTableDDL(db *sql.DB, tableName string) error {
+	dropStmt := GenDropTableStmt(tableName)
+	if _, err := db.Exec(dropStmt); err != nil {
+		fmt.Println(err)
+		return err
+	}
+	return nil
 }

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func GenDropTableStmt(tableName string) string {
 
 func GenCreateTableStmt(columns, primary []ColumnType, tableName string) string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "CREATE TABLE %s(\n", tableName)
+	fmt.Fprintf(&b, "CREATE TABLE IF NOT EXISTS %s(\n", tableName)
 	for i, column := range columns {
 		if column.len > 0 {
 			fmt.Fprintf(&b, "%s %s(%d)", column.name, column.tp, column.len)

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func init() {
 	for k := range dmlExecutors {
 		supportedExecutor = append(supportedExecutor, k)
 	}
+	flag.IntVar(&ddlCnt, "ddl-count", 10, "ddl count, one ddl execution increase at least one schema diff")
 	flag.IntVar(&dmlCnt, "dml-count", 10, "dml count")
 	flag.IntVar(&dmlThread, "dml-thread", 20, "dml thread")
 	flag.StringVar(&dsn1, "dsn1", "root:@tcp(127.0.0.1:4000)/test?tidb_enable_amend_pessimistic_txn=1", "upstream dsn")
@@ -192,6 +193,17 @@ func NewColumnType(i int, name string, tp kv.DataType, len int, null bool) Colum
 	}
 }
 
+func RdColumnsAndPk(leastCol int) ([]ColumnType, []ColumnType) {
+	columns := rdColumns(leastCol)
+	columns[0].null = false
+	primary := []ColumnType{columns[0]}
+	for pi := 1; columns[pi-1].tp == kv.TinyInt || pi <= 2; pi++ {
+		columns[pi].null = false
+		primary = append(primary, columns[pi])
+	}
+	return columns, primary
+}
+
 func rdColumns(least int) []ColumnType {
 	colCnt = util.RdRange(columnLeast, columnMost)
 	if colCnt < least {
@@ -213,7 +225,11 @@ func MustExec(db *sql.DB, sql string) {
 	}
 }
 
-func createTable(columns, primary []ColumnType) string {
+func GenDropTableStmt(tableName string) string {
+	return fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
+}
+
+func GenCreateTableStmt(columns, primary []ColumnType, tableName string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "CREATE TABLE %s(\n", tableName)
 	for i, column := range columns {
@@ -256,17 +272,11 @@ func once(db, db2 *sql.DB, log *Log) error {
 	if txnSize >= int64(200*mbSize) {
 		leastCol = 100
 	}
-	columns := rdColumns(leastCol)
-	columns[0].null = false
-	primary := []ColumnType{columns[0]}
-	for pi := 1; columns[pi-1].tp == kv.TinyInt || pi <= 2; pi++ {
-		columns[pi].null = false
-		primary = append(primary, columns[pi])
-	}
+	columns, primary := RdColumnsAndPk(leastCol)
 	uniqueSets.NewIndex("primary", primary)
 	initThreadName := "init"
-	clearTableStmt := fmt.Sprintf("DROP TABLE IF EXISTS %s", tableName)
-	createTableStmt := createTable(columns, primary)
+	clearTableStmt := GenDropTableStmt(tableName)
+	createTableStmt := GenCreateTableStmt(columns, primary, tableName)
 
 	util.AssertNil(log.NewThread(initThreadName))
 


### PR DESCRIPTION

1. Make `ddl-cnt` configurable, let ddl thread could run more ddl statements.
2. Add unrelated ddl executions in ddl thread, so that the ddl schema diff queue in TiDB will not merge serveral same changes into a single one,  and the schema diff queue could easily increase and exceed the overflow value configured by `tidb_max_delta_schema_count` variable in TiDB.