### PR TITLE
keep old data when update unique to avoid the uk issue

### DIFF
--- a/unique.go
+++ b/unique.go
@@ -152,7 +152,7 @@ func (u *Unique) HasConflict(befores, afters [][]interface{}) bool {
 	return false
 }
 
-func (u *Unique) UpdateEntry(befores, afters [][]interface{}) bool {
+func (u *Unique) UpdateEntry(befores, afters [][]interface{}, keepOldEntry bool) bool {
 	for i := 0; i < len(befores); i++ {
 		beforeEntry, afterEntry := u.row2key(befores[i]), u.row2key(afters[i])
 		if beforeEntry == afterEntry {
@@ -161,7 +161,9 @@ func (u *Unique) UpdateEntry(befores, afters [][]interface{}) bool {
 		if _, ok := u.entries[afterEntry]; ok {
 			return false
 		}
-		delete(u.entries, beforeEntry)
+		if !keepOldEntry {
+			delete(u.entries, beforeEntry)
+		}
 		u.entries[afterEntry] = struct{}{}
 	}
 	return true


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

The following case is unsupported, try to avoid it. This PR might be able to solve #14 .

```sql
/* init */ drop table if exists t;
/* init */ create table t (id int primary key, a int);

/* s1 */ begin;
/* s2 */ begin;
/* s1 */ insert into t values (1, 1);
/* s1 */ update t set a = a + 1 where id = 1;
/* s2 */ insert into t values (2, 1);
/* s3 */ alter table t add unique key uk(a);
/* s2 */ commit;
/* s1 */ commit;
```